### PR TITLE
Replace main code with asyncio.run

### DIFF
--- a/src/yandex_captcha_puzzle_solver/yandex_captcha_puzzle_solver.py
+++ b/src/yandex_captcha_puzzle_solver/yandex_captcha_puzzle_solver.py
@@ -546,14 +546,8 @@ os.environ["REQUESTS_CA_BUNDLE"] = certifi.where()
 os.environ["SSL_CERT_FILE"] = certifi.where()
 
 if __name__ == '__main__':
-  sys.stdout.reconfigure(encoding="utf-8")
-  logger.basicConfig(
-    format='%(asctime)s [%(name)s] [%(levelname)s]: %(message)s',
-    handlers=[logger.StreamHandler(sys.stdout)],
-    level=logging.INFO)
+  async def main() -> None:
+    req = Request({'url': 'https://example.com'})
+    await Solver().solve(req)
 
-  req = Request()
-  req.url = 'https://knopka.ashoo.id'
-
-  solver = Solver()
-  res = solver.solve(req)
+  asyncio.run(main())


### PR DESCRIPTION
## Summary
- update example entrypoint to use `asyncio.run`

## Testing
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --indent-size 2 --max-line-length=100 --ignore E251,W504,C901` *(fails: `F824` unused global variables)*
- `flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --indent-size 2 --ignore E251,W504,C901`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6870ed793fe08321bfb154b0931ade21