### PR TITLE
Fix forward reference error

### DIFF
--- a/src/yandex_captcha_puzzle_solver/yandex_captcha_puzzle_solve_server.py
+++ b/src/yandex_captcha_puzzle_solver/yandex_captcha_puzzle_solve_server.py
@@ -75,10 +75,6 @@ solver_args = {
   'debug_dir': None
 }
 
-# Simple in-memory queue for compatibility API
-_tasks: dict[str, typing.Optional[HandleCommandResponse]] = {}
-_task_counter = 0
-
 
 class ProxyModel(pydantic.BaseModel):
   url: str = pydantic.Field(default=None, description='Proxy url')
@@ -112,6 +108,10 @@ class HandleCommandResponse(pydantic.BaseModel):
   startTimestamp: float
   endTimestamp: float
   solution: typing.Optional[HandleCommandResponseSolution] = None
+
+# Simple in-memory queue for compatibility API
+_tasks: dict[str, typing.Optional[HandleCommandResponse]] = {}
+_task_counter = 0
 
 
 async def process_solve_request(


### PR DESCRIPTION
## Summary
- resolve forward reference by moving `_tasks` declaration after `HandleCommandResponse` class
- ensure tests run successfully on Python 3.11+

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687142f6caac8321835b26b0287cb89d